### PR TITLE
Fix README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## *Warning: this project is still a work-in-progress, and is not yet completely stable!*
 
-![3-way demo](./assets/3-way-example.png)
+![3-way demo](./assets/3-way-example.PNG)
 *Demo of distributed cache with three nodes, using the interactive test mode.*
 
 ## Project Structure


### PR DESCRIPTION
The #5 accidentally renamed ".PNG" to ".png" in the readme which caused GitHub to not render the image.

Was:
![image](https://github.com/gustrain/ladcache/assets/8419211/d95b0bec-12f8-42ca-865c-3708e84d0fd8)

Now:
![image](https://github.com/gustrain/ladcache/assets/8419211/8b94f823-20c0-4dee-83f2-f91bed9f0c6c)
